### PR TITLE
Add endpoint for registering a player move #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TicTacToe
 [![CI](https://github.com/SyedAhmedCU/TicTacToeAPI/actions/workflows/ci.yaml/badge.svg?&service=github)](https://github.com/SyedAhmedCU/TicTacToeAPI/actions/workflows/ci.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/SyedAhmedCU/TicTacToeAPI/badge.svg?branch=2-endpoint-for-starting-a-game&service=github)](https://coveralls.io/github/SyedAhmedCU/TicTacToeAPI?branch=2-endpoint-for-starting-a-game)
+[![Coverage Status](https://coveralls.io/repos/github/SyedAhmedCU/TicTacToeAPI/badge.svg?branch=2-endpoint-for-starting-a-game&service=github&kill_cache=1)](https://coveralls.io/github/SyedAhmedCU/TicTacToeAPI?branch=2-endpoint-for-starting-a-game)
 
 Creating a .NET 6.0 Web API that provides endpoints for managing games of Tic-Tac-Toe. These endpoints are to take the described inputs as JSON strings and return the described output. The API application needs to be runnable using Docker and Docker Compose. Use the most appropriate verbs for the endpoints. Game data should be managed using Entity Framework and a database of your choice (an in-memory database is fine).
 ## Endpoint 1

--- a/TicTacToeAPI.UnitTests/Systems/Controllers/TestGameController.cs
+++ b/TicTacToeAPI.UnitTests/Systems/Controllers/TestGameController.cs
@@ -35,9 +35,9 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
             var dbContext = new TicTacToeAPIDbContext(optionsBuilder.Options);
             //Arrange
             var sut = new GameController(dbContext);
-
+            var gamePlayers = new GamePlayers() { PlayerO = "TestPlayer1", PlayerX = "TestPlayer2" };
             //Act
-            var OkObjectResult = (OkObjectResult)await sut.StartGame("TestPlayer1", "TestPlayer2");
+            var OkObjectResult = (OkObjectResult)await sut.StartGame(gamePlayers);
             //Assert
             OkObjectResult.Value.Should().BeOfType<StartedGame>();
         }
@@ -48,12 +48,16 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
             var optionsBuilder = new DbContextOptionsBuilder<TicTacToeAPIDbContext>()
                 .UseInMemoryDatabase("GameDb");
             var dbContext = new TicTacToeAPIDbContext(optionsBuilder.Options);
+
             //Arrange
             var sut = new GameController(dbContext);
             //start a game
-            await sut.StartGame("TestPlayer1", "TestPlayer2");
+            var gamePlayers = new GamePlayers() { PlayerO = "TestPlayer1", PlayerX = "TestPlayer2" };
+            await sut.StartGame(gamePlayers);
+
             //Act
             var OkObjectResult = (OkObjectResult)await sut.GetCurrentGames();
+
             //Assert
             OkObjectResult.Value.Should().BeOfType<List<ActiveGame>>();
         }
@@ -64,15 +68,16 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
             var optionsBuilder = new DbContextOptionsBuilder<TicTacToeAPIDbContext>()
                 .UseInMemoryDatabase("GameDb");
             var dbContext = new TicTacToeAPIDbContext(optionsBuilder.Options);
+
             //Arrange
             var sut = new GameController(dbContext);
+            var gamePlayers = new GamePlayers() { PlayerO = "SameTestPlayer", PlayerX = "SameTestPlayer" };
 
             //Act
-            //adding same player should return a bad request 
-            var OkObjectResult = (OkObjectResult)await sut.StartGame("TestPlayer1", "TestPlayer2");
-            var BadRequestObjectResult = (BadRequestObjectResult)await sut.StartGame("SameTestPlayer", "SameTestPlayer");
+            //adding same players should return a bad request 
+            var BadRequestObjectResult = (BadRequestObjectResult)await sut.StartGame(gamePlayers);
+
             //Assert
-            OkObjectResult.Value.Should().BeOfType<StartedGame>();
             BadRequestObjectResult.StatusCode.Should().Be(400);
         }
     }

--- a/TicTacToeAPI.UnitTests/Systems/Controllers/TestMoveController.cs
+++ b/TicTacToeAPI.UnitTests/Systems/Controllers/TestMoveController.cs
@@ -1,0 +1,36 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using TicTacToeAPI.Controllers;
+using TicTacToeAPI.Data;
+using TicTacToeAPI.Model;
+using Xunit;
+
+namespace TicTacToeAPI.UnitTests.Systems.Controllers
+{
+    public class MovePlayerController
+    {
+        [Fact]
+        public async Task Post_OnSuccess_ReturnStatusCode200()
+        {
+            //add in memory database context
+            var optionsBuilder = new DbContextOptionsBuilder<TicTacToeAPIDbContext>()
+                .UseInMemoryDatabase("GameDb");
+            var dbContext = new TicTacToeAPIDbContext(optionsBuilder.Options);
+            //Arrange
+            var sut = new MoveController(dbContext);
+            //add a new game
+            var newGame = new Game { Id = Guid.NewGuid(), PlayerX = "TestPlayer1", PlayerO = "TestPlayer1", GameStatus = GameState.ongoing, MoveRegistered = 0 };
+            await dbContext.Games.AddAsync(newGame);
+            await dbContext.SaveChangesAsync();
+
+            var newMove = new NewMove() { GameID = newGame.Id.ToString(), MoveIndex = 0, PlayerNameId = "TestPlayer1" };
+
+            //Act
+            var result = (OkObjectResult)await sut.PostNewMove(newMove);
+
+            //Assert
+            result.StatusCode.Should().Be(200);
+        }
+    }
+}

--- a/TicTacToeAPI.UnitTests/Systems/Controllers/TestMoveController.cs
+++ b/TicTacToeAPI.UnitTests/Systems/Controllers/TestMoveController.cs
@@ -1,6 +1,8 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Runtime.Intrinsics.X86;
+using System;
 using TicTacToeAPI.Controllers;
 using TicTacToeAPI.Data;
 using TicTacToeAPI.Model;
@@ -20,17 +22,64 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
             //Arrange
             var sut = new MoveController(dbContext);
             //add a new game
-            var newGame = new Game { Id = Guid.NewGuid(), PlayerX = "TestPlayer1", PlayerO = "TestPlayer1", GameStatus = GameState.ongoing, MoveRegistered = 0 };
+            var newGame = new Game { Id = Guid.NewGuid(), PlayerX = "TestPlayer1", PlayerO = "TestPlayer2", GameStatus = GameState.ongoing, MoveRegistered = 0 };
             await dbContext.Games.AddAsync(newGame);
             await dbContext.SaveChangesAsync();
 
             var newMove = new NewMove() { GameID = newGame.Id.ToString(), MoveIndex = 0, PlayerNameId = "TestPlayer1" };
 
             //Act
-            var result = (OkObjectResult)await sut.PostNewMove(newMove);
+            var result2 = await sut.PostNewMove(newMove);
+            var result = (OkObjectResult)result2;
 
             //Assert
             result.StatusCode.Should().Be(200);
+        }
+        [Fact]
+        public async Task Post_ExceptionalCase1_ReturnStatusCode400()
+        {
+            //add in memory database context
+            var optionsBuilder = new DbContextOptionsBuilder<TicTacToeAPIDbContext>()
+                .UseInMemoryDatabase("GameDb");
+            var dbContext = new TicTacToeAPIDbContext(optionsBuilder.Options);
+            //Arrange
+            var sut = new MoveController(dbContext);
+            //add a new game
+            var newGame = new Game { Id = Guid.NewGuid(), PlayerX = "TestPlayer1", PlayerO = "TestPlayer2", GameStatus = GameState.ongoing, MoveRegistered = 0 };
+            await dbContext.Games.AddAsync(newGame);
+            await dbContext.SaveChangesAsync();
+
+            //Invalid game id
+            var newMove = new NewMove() { GameID = "InvalidGameID", MoveIndex = 0, PlayerNameId = "TestPlayer1" };
+
+            //Act
+            var badRequestObjectResult = (BadRequestObjectResult)await sut.PostNewMove(newMove);
+
+            //Assert
+            badRequestObjectResult.StatusCode.Should().Be(400);
+        }
+        [Fact]
+        public async Task Post_ExceptionalCase2_ReturnStatusCode400()
+        {
+            //add in memory database context
+            var optionsBuilder = new DbContextOptionsBuilder<TicTacToeAPIDbContext>()
+                .UseInMemoryDatabase("GameDb");
+            var dbContext = new TicTacToeAPIDbContext(optionsBuilder.Options);
+            //Arrange
+            var sut = new MoveController(dbContext);
+            //add a new game
+            var newGame = new Game { Id = Guid.NewGuid(), PlayerX = "TestPlayer1", PlayerO = "TestPlayer2", GameStatus = GameState.draw, MoveRegistered = 0 };
+            await dbContext.Games.AddAsync(newGame);
+            await dbContext.SaveChangesAsync();
+
+            //game already finished
+            var newMove = new NewMove() { GameID = newGame.Id.ToString(), MoveIndex = 0, PlayerNameId = "TestPlayer1" };
+
+            //Act
+            var badRequestObjectResult = (BadRequestObjectResult)await sut.PostNewMove(newMove);
+
+            //Assert
+            badRequestObjectResult.StatusCode.Should().Be(400);
         }
     }
 }

--- a/TicTacToeAPI.UnitTests/Systems/Controllers/TestMoveController.cs
+++ b/TicTacToeAPI.UnitTests/Systems/Controllers/TestMoveController.cs
@@ -102,7 +102,7 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
             await dbContext.Games.AddAsync(newGame);
             await dbContext.SaveChangesAsync();
 
-            //game already finished
+            //player is not register in the game 
             var newMove = new NewMove() { GameID = newGame.Id.ToString(), MoveIndex = 0, PlayerNameId = "InvalidPlayerID" };
 
             //Act
@@ -113,6 +113,72 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
             //test message
             var expectedMessage = Assert.IsType<string>(badRequestObjectResult.Value);
             Assert.Equal("Player is not in this game.", expectedMessage);
+        }
+        [Fact]
+        public async Task Post_MoveAlreadyRegisterd_ReturnStatusCode400WithErrorMsg()
+        {
+            //add in memory database context
+            var optionsBuilder = new DbContextOptionsBuilder<TicTacToeAPIDbContext>()
+                .UseInMemoryDatabase("GameDb");
+            var dbContext = new TicTacToeAPIDbContext(optionsBuilder.Options);
+            //Arrange
+            var sut = new MoveController(dbContext);
+            //add a new game
+            var newGame = new Game { Id = Guid.NewGuid(), PlayerX = "TestPlayer1", PlayerO = "TestPlayer2", GameStatus = GameState.ongoing, MoveRegistered = 0 };
+            await dbContext.Games.AddAsync(newGame);
+            await dbContext.SaveChangesAsync();
+
+            //select move index 4
+            var oldMove = new NewMove() { GameID = newGame.Id.ToString(), MoveIndex = 4, PlayerNameId = "TestPlayer1" };
+            //select move index 4 again
+            var newMove = new NewMove() { GameID = newGame.Id.ToString(), MoveIndex = 4, PlayerNameId = "TestPlayer2" };
+
+            //Act
+            var okObjectResult = (OkObjectResult)await sut.PostNewMove(oldMove);
+            var badRequestObjectResult = (BadRequestObjectResult)await sut.PostNewMove(newMove);
+
+            //Assert
+            //old move is registered successfully
+            okObjectResult.StatusCode.Should().Be(200);
+            //new move is not registered
+            badRequestObjectResult.StatusCode.Should().Be(400);
+            //test message
+            var expectedMessage = Assert.IsType<string>(badRequestObjectResult.Value);
+            Assert.Equal("Move already registered. Try another.", expectedMessage);
+        }
+        [Fact]
+        public async Task Post_InvalidMoveIndex_ReturnStatusCode400WithErrorMsg()
+        {
+            //add in memory database context
+            var optionsBuilder = new DbContextOptionsBuilder<TicTacToeAPIDbContext>()
+                .UseInMemoryDatabase("GameDb");
+            var dbContext = new TicTacToeAPIDbContext(optionsBuilder.Options);
+            //Arrange
+            var sut = new MoveController(dbContext);
+            //add a new game
+            var newGame = new Game { Id = Guid.NewGuid(), PlayerX = "TestPlayer1", PlayerO = "TestPlayer2", GameStatus = GameState.ongoing, MoveRegistered = 0};
+            await dbContext.Games.AddAsync(newGame);
+            await dbContext.SaveChangesAsync();
+
+            //move index 0-8 is valid
+            var moveInvalid1 = new NewMove() { GameID = newGame.Id.ToString(), MoveIndex = -1, PlayerNameId = "TestPlayer1" };
+            var moveInvalid2 = new NewMove() { GameID = newGame.Id.ToString(), MoveIndex = 9, PlayerNameId = "TestPlayer2" };
+            var moveValid = new NewMove() { GameID = newGame.Id.ToString(), MoveIndex = 5, PlayerNameId = "TestPlayer1" };
+
+            //Act
+            var badRequestObjectResult1 = (BadRequestObjectResult)await sut.PostNewMove(moveInvalid1);
+            var badRequestObjectResult2 = (BadRequestObjectResult)await sut.PostNewMove(moveInvalid2);
+            var okObjectResult = (OkObjectResult)await sut.PostNewMove(moveValid);
+
+            //Assert
+            badRequestObjectResult1.StatusCode.Should().Be(400);
+            badRequestObjectResult2.StatusCode.Should().Be(400);
+            okObjectResult.StatusCode.Should().Be(200);
+            //test messaged
+            var expectedMessage1 = Assert.IsType<string>(badRequestObjectResult1.Value);
+            var expectedMessage2 = Assert.IsType<string>(badRequestObjectResult2.Value);
+            Assert.Equal("Invalid move, choose between 0-8.", expectedMessage1);
+            Assert.Equal("Invalid move, choose between 0-8.", expectedMessage2);
         }
     }
 }

--- a/TicTacToeAPI.UnitTests/Systems/Controllers/TestMoveController.cs
+++ b/TicTacToeAPI.UnitTests/Systems/Controllers/TestMoveController.cs
@@ -29,14 +29,15 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
             var newMove = new NewMove() { GameID = newGame.Id.ToString(), MoveIndex = 0, PlayerNameId = "TestPlayer1" };
 
             //Act
-            var result2 = await sut.PostNewMove(newMove);
-            var result = (OkObjectResult)result2;
+            var okObjectResult = (OkObjectResult)await sut.PostNewMove(newMove);
 
             //Assert
-            result.StatusCode.Should().Be(200);
+            okObjectResult.StatusCode.Should().Be(200);
+            var expectedMessage = Assert.IsType<string>(okObjectResult.Value);
+            Assert.Equal("Move is registered successfully!", expectedMessage);
         }
         [Fact]
-        public async Task Post_ExceptionalCase1_ReturnStatusCode400()
+        public async Task Post_ExceptionalCase1_ReturnStatusCode400WithErrorMsg()
         {
             //add in memory database context
             var optionsBuilder = new DbContextOptionsBuilder<TicTacToeAPIDbContext>()
@@ -57,9 +58,12 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
 
             //Assert
             badRequestObjectResult.StatusCode.Should().Be(400);
+            //test message
+            var expectedMessage = Assert.IsType<string>(badRequestObjectResult.Value);
+            Assert.Equal("No ongoing game was found with the game id. Please use correct game id or start a game.", expectedMessage);
         }
         [Fact]
-        public async Task Post_ExceptionalCase2_ReturnStatusCode400()
+        public async Task Post_ExceptionalCase2_ReturnStatusCode400WithErrorMsg()
         {
             //add in memory database context
             var optionsBuilder = new DbContextOptionsBuilder<TicTacToeAPIDbContext>()
@@ -80,6 +84,9 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
 
             //Assert
             badRequestObjectResult.StatusCode.Should().Be(400);
+            //test message
+            var expectedMessage = Assert.IsType<string>(badRequestObjectResult.Value);
+            Assert.Equal("No ongoing game was found with the game id. Please use correct game id or start a game.", expectedMessage);
         }
     }
 }

--- a/TicTacToeAPI.UnitTests/Systems/Controllers/TestPlayerController.cs
+++ b/TicTacToeAPI.UnitTests/Systems/Controllers/TestPlayerController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TicTacToeAPI.Controllers;
 using TicTacToeAPI.Data;
+using TicTacToeAPI.Model;
 using Xunit;
 
 namespace TicTacToeAPI.UnitTests.Systems.Controllers
@@ -34,11 +35,11 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
             var dbContext = new TicTacToeAPIDbContext(optionsBuilder.Options);
             //Arrange
             var sut = new PlayerController(dbContext);
-
+            var testPlayer = new NewPlayer() { Name = "TestPlayer" };
             //Act
-            var OkObjectResult = (OkObjectResult)await sut.AddPlayer("TestPlayer");
+            var OkObjectResult = (OkObjectResult)await sut.AddPlayer(testPlayer);
             //Assert
-            OkObjectResult.Value.Should().BeOfType<Model.Player>();
+            OkObjectResult.Value.Should().BeOfType<Player>();
         }
         [Fact]
         public async Task Post_OnSuccess_ReturnStatusCode400PlayerExist()
@@ -49,13 +50,14 @@ namespace TicTacToeAPI.UnitTests.Systems.Controllers
             var dbContext = new TicTacToeAPIDbContext(optionsBuilder.Options);
             //Arrange
             var sut = new PlayerController(dbContext);
-
+            var testPlayer1 = new NewPlayer() { Name = "SameTestPlayer" };
+            var testPlayer2 = new NewPlayer() { Name = "SameTestPlayer" };
             //Act
             //adding same player should return a bad request 
-            var OkObjectResult = (OkObjectResult)await sut.AddPlayer("SameTestPlayer");
-            var BadRequestObjectResult = (BadRequestObjectResult)await sut.AddPlayer("SameTestPlayer");
+            var OkObjectResult = (OkObjectResult)await sut.AddPlayer(testPlayer1);
+            var BadRequestObjectResult = (BadRequestObjectResult)await sut.AddPlayer(testPlayer2);
             //Assert
-            OkObjectResult.Value.Should().BeOfType<Model.Player>();
+            OkObjectResult.Value.Should().BeOfType<Player>();
             BadRequestObjectResult.StatusCode.Should().Be(400);
         }
     }

--- a/TicTacToeAPI/Controllers/GameController.cs
+++ b/TicTacToeAPI/Controllers/GameController.cs
@@ -48,32 +48,33 @@ namespace TicTacToeAPI.Controllers
         /// If both name ids are same, returns bad request 400.
         /// </returns>
         [HttpPost]
-        public async Task<IActionResult> StartGame(string playerX, string playerO)
+        public async Task<IActionResult> StartGame(GamePlayers gamePlayers)
         {
-            var xPlayer = await dbContext.Players.Where(p => p.Name == playerX).FirstOrDefaultAsync();
-            var oPlayer = await dbContext.Players.Where(p => p.Name == playerO).FirstOrDefaultAsync();
+            var xPlayer = await dbContext.Players.Where(p => p.Name == gamePlayers.PlayerX).FirstOrDefaultAsync();
+            var oPlayer = await dbContext.Players.Where(p => p.Name == gamePlayers.PlayerO).FirstOrDefaultAsync();
 
-            if (playerX == playerO)
-                return BadRequest("PlayerX and PlayerO cant be same.");
+            if (gamePlayers.PlayerX == gamePlayers.PlayerO)
+                return BadRequest("PlayerX and PlayerO can't be same.");
+            //add PlayerX and PlayerO if they don't exist database
             if (xPlayer == null)
             {
                 var newPlayer = new Player()
                 {
-                    Name = playerX
+                    Name = gamePlayers.PlayerX
                 };
                 await dbContext.Players.AddAsync(newPlayer);
                 await dbContext.SaveChangesAsync();
-                xPlayer = await dbContext.Players.Where(p => p.Name == playerX).FirstOrDefaultAsync();
+                xPlayer = await dbContext.Players.Where(p => p.Name == gamePlayers.PlayerX).FirstOrDefaultAsync();
             }
             if (oPlayer == null)
             {
                 var newPlayer = new Player()
                 {
-                    Name = playerO
+                    Name = gamePlayers.PlayerO
                 };
                 await dbContext.Players.AddAsync(newPlayer);
                 await dbContext.SaveChangesAsync();
-                oPlayer = await dbContext.Players.Where(p => p.Name == playerO).FirstOrDefaultAsync();
+                oPlayer = await dbContext.Players.Where(p => p.Name == gamePlayers.PlayerO).FirstOrDefaultAsync();
             }
 
             var game = new Game()

--- a/TicTacToeAPI/Controllers/MoveController.cs
+++ b/TicTacToeAPI/Controllers/MoveController.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using TicTacToeAPI.Data;
+
+namespace TicTacToeAPI.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class MoveController : ControllerBase
+    {
+        //Dependency injection for in memory database context
+        private readonly TicTacToeAPIDbContext dbContext;
+        public MoveController(TicTacToeAPIDbContext dbContext)
+        {
+            this.dbContext = dbContext;
+        }
+    }
+}

--- a/TicTacToeAPI/Controllers/MoveController.cs
+++ b/TicTacToeAPI/Controllers/MoveController.cs
@@ -37,7 +37,7 @@ namespace TicTacToeAPI.Controllers
                 return BadRequest("Move already registered. Try another.");
 
             //check if the move is outside limit (0-8)
-            if (newMove.MoveIndex < (int)MoveConstraint.firstPlace && newMove.MoveIndex > (int)MoveConstraint.lastPlace)
+            if (newMove.MoveIndex < (int)MoveConstraint.firstPlace || newMove.MoveIndex > (int)MoveConstraint.lastPlace)
                 return BadRequest("Invalid move, choose between 0-8.");
 
             //If the move passes the validation, increase the move count

--- a/TicTacToeAPI/Controllers/MoveController.cs
+++ b/TicTacToeAPI/Controllers/MoveController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using TicTacToeAPI.Data;
+using TicTacToeAPI.Model;
 
 namespace TicTacToeAPI.Controllers
 {
@@ -13,6 +15,48 @@ namespace TicTacToeAPI.Controllers
         public MoveController(TicTacToeAPIDbContext dbContext)
         {
             this.dbContext = dbContext;
+        }
+        [HttpPost]
+        public async Task<IActionResult> RegisterMove(NewMove newMove)
+        {
+            var gameExist = await dbContext.Games.Where(g => g.Id.ToString() == newMove.GameID && g.GameStatus == GameState.ongoing).FirstOrDefaultAsync();
+            // find a game with the game id 
+            if (gameExist == null)
+                return NotFound("No ongoing game was found with the game id. Please use correct game id or start a game.");
+
+            //check if the player is in the game
+            var playerX = gameExist.PlayerX;
+            var playerO = gameExist.PlayerO;
+            var currentPlayer = newMove.PlayerNameId;
+            if (currentPlayer != playerX && currentPlayer != playerO)
+                return BadRequest("Player is not in this game.");
+
+            //check if the move is available or already registered
+            var moveExist = await dbContext.Moves.Where(g => g.GameID.ToString() == newMove.GameID && g.MoveIndex == newMove.MoveIndex).FirstOrDefaultAsync();
+            if (moveExist != null)
+                return BadRequest("Move already registered. Try another.");
+
+            //check if the move is outside limit (0-8)
+            if (newMove.MoveIndex < (int)MoveConstraint.firstPlace && newMove.MoveIndex > (int)MoveConstraint.lastPlace)
+                return BadRequest("Invalid move, choose between 0-8.");
+
+            //If the move passes the validation, increase the move count
+            var latestMoveCount = gameExist.MoveRegistered + 1;
+
+            var move = new Move()
+            {
+                GameID = newMove.GameID,
+                PlayerNameId = newMove.PlayerNameId,
+                MoveIndex = newMove.MoveIndex
+            };
+
+            //register current move
+            await dbContext.Moves.AddAsync(move);
+            //update newly registered move in the game 
+            gameExist.MoveRegistered = latestMoveCount;
+            await dbContext.SaveChangesAsync();
+
+            return Ok(move);
         }
     }
 }

--- a/TicTacToeAPI/Controllers/MoveController.cs
+++ b/TicTacToeAPI/Controllers/MoveController.cs
@@ -16,6 +16,11 @@ namespace TicTacToeAPI.Controllers
         {
             this.dbContext = dbContext;
         }
+        /// <summary>
+        /// Takes player's name id, game id and move and store it  
+        /// </summary>
+        /// <param name="newMove"></param>
+        /// <returns>If all validates, returns success response or appropriate errors.</returns>
         [HttpPost]
         public async Task<IActionResult> PostNewMove(NewMove newMove)
         {

--- a/TicTacToeAPI/Controllers/MoveController.cs
+++ b/TicTacToeAPI/Controllers/MoveController.cs
@@ -17,7 +17,7 @@ namespace TicTacToeAPI.Controllers
             this.dbContext = dbContext;
         }
         [HttpPost]
-        public async Task<IActionResult> RegisterMove(NewMove newMove)
+        public async Task<IActionResult> PostNewMove(NewMove newMove)
         {
             var gameExist = await dbContext.Games.Where(g => g.Id.ToString() == newMove.GameID && g.GameStatus == GameState.ongoing).FirstOrDefaultAsync();
             // find a game with the game id 
@@ -56,7 +56,7 @@ namespace TicTacToeAPI.Controllers
             gameExist.MoveRegistered = latestMoveCount;
             await dbContext.SaveChangesAsync();
 
-            return Ok(move);
+            return Ok("Move is registered successfully!");
         }
     }
 }

--- a/TicTacToeAPI/Controllers/MoveController.cs
+++ b/TicTacToeAPI/Controllers/MoveController.cs
@@ -22,7 +22,7 @@ namespace TicTacToeAPI.Controllers
             var gameExist = await dbContext.Games.Where(g => g.Id.ToString() == newMove.GameID && g.GameStatus == GameState.ongoing).FirstOrDefaultAsync();
             // find a game with the game id 
             if (gameExist == null)
-                return NotFound("No ongoing game was found with the game id. Please use correct game id or start a game.");
+                return BadRequest("No ongoing game was found with the game id. Please use correct game id or start a game.");
 
             //check if the player is in the game
             var playerX = gameExist.PlayerX;

--- a/TicTacToeAPI/Controllers/PlayerController.cs
+++ b/TicTacToeAPI/Controllers/PlayerController.cs
@@ -34,20 +34,20 @@ namespace TicTacToeAPI.Controllers
         /// If the player already exist, returns bad request with a string message.
         /// </returns>
         [HttpPost]
-        public async Task<IActionResult> AddPlayer(string name)
+        public async Task<IActionResult> AddPlayer(NewPlayer newPlayer)
         {
-            var newPlayer = new Player()
+            var registerPlayer = new Player()
             {
-                Name = name
+                Name = newPlayer.Name,
             };
-            var nameExist = await dbContext.Players.Where(p => p.Name.ToLower() == name.ToLower()).FirstOrDefaultAsync();
+            var nameExist = await dbContext.Players.Where(p => p.Name.ToLower() == registerPlayer.Name.ToLower()).FirstOrDefaultAsync();
             if (nameExist != null)
             {
                 return BadRequest("Player already exist, try a different name.");
             }
-            await dbContext.Players.AddAsync(newPlayer);
+            await dbContext.Players.AddAsync(registerPlayer);
             await dbContext.SaveChangesAsync();
-            return Ok(newPlayer);
+            return Ok(registerPlayer);
         }
     }
 }

--- a/TicTacToeAPI/Model/Game.cs
+++ b/TicTacToeAPI/Model/Game.cs
@@ -1,30 +1,34 @@
 ﻿namespace TicTacToeAPI.Model
 {
-    public class Game
+    public class GamePlayers
     {
-        public Guid Id { get; set; }
         public string PlayerX { get; set; } = string.Empty;
         public string PlayerO { get; set; } = string.Empty;
+    }
+    public class Game : GamePlayers
+    {
+        public Guid Id { get; set; }
         public GameState GameStatus { get; set; } = GameState.ongoing;
         public int? MoveRegistered { get; set; } = 0;
     }
+    /// <summary>
+    /// GameState enum : ongoing = 0, playerXwin = 1, playerOwin = 2, draw=3
+    /// </summary>
     public enum GameState { ongoing, playerXwin, playerOwin, draw }
 
-    //class for showing newly started game
-    public class StartedGame 
+    /// <summary>
+    /// Class for showing newly started game with player name and game id
+    /// </summary>
+    public class StartedGame  : GamePlayers
     {
        public string GameId { get; set; } = string.Empty;
-       public string PlayerX { get; set; } = string.Empty;
-       public string PlayerO { get; set; } = string.Empty;
     }
-    //class for showing list of running games
-    public class ActiveGame
+    /// <summary>
+    /// Class for showing list of running games includes game id, status, players and mode registerd for each
+    /// </summary>
+    public class ActiveGame : StartedGame
     {
-        public string GameId { get; set; } = string.Empty;
-        public string PlayerX { get; set; } = string.Empty;
-        public string PlayerO { get; set; } = string.Empty;
         public string GameStatus { get; set; } = string.Empty;
         public int? MoveRegistered { get; set; } = 0;
     }
-
 }

--- a/TicTacToeAPI/Model/Move.cs
+++ b/TicTacToeAPI/Model/Move.cs
@@ -1,10 +1,18 @@
 ﻿namespace TicTacToeAPI.Model
 {
-    public class Move
+    public class NewMove
     {
-        public Guid Id { get; set; }
-        public int PlayerId { get; set; }
+        public string PlayerNameId { get; set; } = string.Empty;
         public string GameID { get; set; } = string.Empty;
         public int MoveIndex { get; set; }
     }
+    //For creating dbset 
+    public class Move : NewMove
+    {
+        public Guid Id { get; set; }
+    }
+    /// <summary>
+    /// Tictactoe has total 9 places where player can move, 0, 1 ,2, 3,4 ,5,6,7, 8,9
+    /// </summary>
+    public enum MoveConstraint { firstPlace = 0, lastPlace = 8 }
 }

--- a/TicTacToeAPI/Model/Player.cs
+++ b/TicTacToeAPI/Model/Player.cs
@@ -1,8 +1,11 @@
 ﻿namespace TicTacToeAPI.Model
 {
-    public class Player
+    public class NewPlayer
     {
-        public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
+    }
+    public class Player : NewPlayer
+    {
+        public Guid Id { get; set; }
     }
 }


### PR DESCRIPTION
### **Add endpoint for registering a player move #3 
- This endpoint uses HttpPost method for registering a player move. It take the player name Id, game Id and the move (index) and return a success response or appropriate errors as bad requests with a messages. 
- There multiple validation which checks for invalid game id, player id, previously registered move and invalid move index. 
- Total 6 unit tests were written to test the success and error responses. 
